### PR TITLE
Add name attribute to the test suite containing all test suite.

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -106,7 +106,7 @@ class Command extends AbstractCommand
 
         // here is where the magic happens
         $files = $this->findFiles($directory, $names, $ignoreNames);
-        $outXml = $this->mergeFiles($files);
+        $outXml = $this->mergeFiles(realpath($directory), $files);
         $result = $this->writeFile($outXml, $fileOut);
 
         $output->writeln(
@@ -148,11 +148,12 @@ class Command extends AbstractCommand
     /**
      * Merge all files.
      *
+     * @param string $directory
      * @param Finder $finder
      *
      * @return fDOMDocument
      */
-    protected function mergeFiles(Finder $finder)
+    protected function mergeFiles($directory, Finder $finder)
     {
         $outXml = new fDOMDocument;
         $outXml->formatOutput = true;
@@ -183,6 +184,7 @@ class Command extends AbstractCommand
             }
         }
 
+        $outTestSuite->setAttribute('name', $directory);
         $outTestSuite->setAttribute('tests', $tests);
         $outTestSuite->setAttribute('assertions', $assertions);
         $outTestSuite->setAttribute('failures', $failures);


### PR DESCRIPTION
This is necessary for Jenkins xUnit plugin not to complain about the following:

junit.xml:cvc-complex-type.4: Attribute 'name' must appear on element 'testsuite'.

(event though none of the XSD in https://github.com/jenkinsci/xunit-plugin/tree/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd require it)
