### PR TITLE
suffix test suites with duplicate names

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -188,7 +188,17 @@ class Command extends AbstractCommand
 
             $inXml = $this->loadFile($file->getRealpath());
             foreach ($inXml->query('//testsuites/testsuite') as $inElement) {
+
+                $inName = $inElement->getAttribute('name');
+                $outName = $inName;
+                $suffix = 2;
+                while ($outTestSuite->query('//testsuite[@name="' . $outName . '"]')->length !== 0) {
+                    $outName = $inName . '_' . $suffix;
+                    $suffix++;
+                }
+
                 $outElement = $outXml->importNode($inElement, true);
+                $outElement->setAttribute('name', $outName);
                 $outTestSuite->appendChild($outElement);
 
                 $tests += $inElement->getAttribute('tests');


### PR DESCRIPTION
Most jUnit parsers seem to expect that sibling test suites have unique names, and they yield unexpected results when interpreting files containing duplicate suite names, either over- or under-counting results.

This change applies a common _2, _3, etc. suffix on merging suites into the output file should a suite of the same name already exist.
