### PR TITLE
fix autoloading in phar

### DIFF
--- a/phpjunitmerge
+++ b/phpjunitmerge
@@ -2,21 +2,21 @@
 <?php
 /**
  * phpjunitmerge
- * 
+ *
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2014, Andreas Weber <code@andreas-weber.me>.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,7 +34,7 @@
 
 $loaded = false;
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array('phar://' . __FILE__ . '/vendor/autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         require $file;
         $loaded = true;


### PR DESCRIPTION
This project could be packed into a phar except that autoloading implemented in the current executable does not resolve properly when run from inside an archive. Adding an additional autoload check to account for that case has no negative side effects and adds minimal phar support.

FYI, the phar was built with robo (http://robo.li)

robo phar:build ~/src/php-junit-merge/ ~/src/php-junit-merge/phpjunitmerge

``` php
// RoboFile.php:
<?php
/**
 * This is project's console commands configuration for Robo task runner.
 *
 * @see http://robo.li/
 */

class RoboFile extends \Robo\Tasks {
  public function pharBuild($src_path, $exe_path) {
    $src_path = realpath($src_path);
    $exe_path = realpath($exe_path);

    $exe = new \SplFileInfo($exe_path);

    $packer = $this->taskPackPhar($exe->getBasename('.php') . '.phar');

    $this->taskComposerInstall()
        ->dir($src_path)
        ->noDev()
        ->printed(false)
        ->run();

    $files = \Symfony\Component\Finder\Finder::create()->ignoreVCS(true)
        ->files()
        ->name('*.php')
        ->path('src')
        ->path('vendor')
        ->exclude('*/*/Tests') // for vendor
        ->exclude('*/*/tests') // for vendor
        ->exclude('Test') // since tests are contained within php-junit-merge/src/Test
        ->in($src_path);
    foreach ($files as $file) {
      $packer->addFile($file->getRelativePathname(), $file->getRealPath());
    }

    $packer->executable($exe->getRealPath());
    $packer->run();
  }
}
```
