### PR TITLE
Allow Symfony3 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/console": "~2.4",
-        "symfony/finder": "~2.4",
+        "symfony/console": "~2.4|^3.0",
+        "symfony/finder": "~2.4|^3.0",
         "theseer/fdomdocument": "1.6.*"
     },
     "require-dev": {


### PR DESCRIPTION
The script is working with Symfony3 components as well (tested with Symfony 3.0.6) without any modifications.
It is safe to upgrade as deprecated classes are not used.
