### PR TITLE
Update dependences: phpUnit to 5 and add support for symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",
-        "phploc/phploc": "2.0.*",
+        "phploc/phploc": "3.*",
         "squizlabs/php_codesniffer": "1.5.*",
-        "phpmd/phpmd": "2.0.*",
+        "phpmd/phpmd": "2.*",
         "sebastian/phpcpd": "2.0.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/andreas-weber/php-junit-merge/issues"
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "symfony/console": "^3.0|^4.0",
         "symfony/finder": "^3.0|^4.0",
         "theseer/fdomdocument": "1.6.*"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/andreas-weber/php-junit-merge/issues"
     },
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "symfony/console": "^3.0|^4.0",
         "symfony/finder": "^3.0|^4.0",
         "theseer/fdomdocument": "1.6.*"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "theseer/fdomdocument": "1.6.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "^5.0",
         "phploc/phploc": "2.0.*",
         "squizlabs/php_codesniffer": "1.5.*",
         "phpmd/phpmd": "2.0.*",

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     },
     "require": {
         "php": ">=5.6",
-        "symfony/console": "^3.0|^4.0",
-        "symfony/finder": "^3.0|^4.0",
+        "symfony/console": "^3.0 || ^4.0",
+        "symfony/finder": "^3.0 || ^4.0",
         "theseer/fdomdocument": "1.6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",
-        "phploc/phploc": "3.*",
+        "phploc/phploc": "4.*",
         "squizlabs/php_codesniffer": "1.5.*",
         "phpmd/phpmd": "2.*",
         "sebastian/phpcpd": "2.0.*"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/console": "~2.4|^3.0",
-        "symfony/finder": "~2.4|^3.0",
+        "symfony/console": "^3.0|^4.0",
+        "symfony/finder": "^3.0|^4.0",
         "theseer/fdomdocument": "1.6.*"
     },
     "require-dev": {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -55,7 +55,7 @@ class Application extends ConsoleApplication
      */
     public function __construct()
     {
-        parent::__construct('phpjunitmerge', '1.0.5');
+        parent::__construct('phpjunitmerge', '1.0.6');
     }
 
     /**


### PR DESCRIPTION
This pull-request adds support for Symfony 4 and removes deprecated warning in php 7.2 for 'each'-function from phpUnit 4. PhpUnit is also updated to 5 version.
In this regard, the minimally supported version of PHP is 5.6.