### PR TITLE
Check that attributes exist before adding them to the count

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -214,11 +214,11 @@ class Command extends AbstractCommand
 				}
                 $outTestSuite->appendChild($outElement);
 
-                $tests += $inElement->getAttribute('tests');
-                $assertions += $inElement->getAttribute('assertions');
-                $failures += $inElement->getAttribute('failures');
-                $errors += $inElement->getAttribute('errors');
-                $time += $inElement->getAttribute('time');
+                $tests += $inElement->hasAttribute('tests') ? $inElement->getAttribute('tests') : 0;
+                $assertions += $inElement->hasAttribute('assertions') ? $inElement->getAttribute('assertions') : 0;
+                $failures += $inElement->hasAttribute('failures') ? $inElement->getAttribute('failures') : 0;
+                $errors += $inElement->hasAttribute('errors') ? $inElement->getAttribute('errors') : 0;
+                $time += $inElement->hasAttribute('time') ? $inElement->getAttribute('time') : 0;
             }
         }
 

--- a/src/Test/Unit/Fixtures/normal/phpcs-junit-1.xml
+++ b/src/Test/Unit/Fixtures/normal/phpcs-junit-1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="PHP_CodeSniffer 3.5.5" errors="0" tests="2" failures="0">
+    <testsuite name="Unit/Testsuite1.php" errors="0" tests="1" failures="0">
+        <testcase name="Unit/Testsuite1.php" />
+    </testsuite>
+    <testsuite name="Unit/Testsuite2.php" errors="0" tests="1" failures="0">
+        <testcase name="Unit/Testsuite2.php" />
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
In this PR we add a check on the attributes that are taken into account for the purposes of counting `tests`, `assertions`, `failures`, `errors` and `time`. 

Some XML reports in jUnit format may not always have these attributes, for example the report file generated by `PHP_CodeSniffer`. 

This can cause warning messages like this: 
`PHP Warning: A non-numeric value encountered in /vendor/andreas-weber/php-junit-merge/src/Console/Command.php on line 221`
